### PR TITLE
Adding #ifndef DHT_H to header file

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -1,3 +1,5 @@
+#ifndef DHT_H
+#define DHT_H
 #if ARDUINO >= 100
  #include "Arduino.h"
 #else
@@ -34,3 +36,4 @@ class DHT {
   float readHumidity(void);
 
 };
+#endif


### PR DESCRIPTION
Added a basic #ifndef DHT_H to the dht.h file so that if you have a
larger program and want to access the sensor from a different file, you
don't import it twice.
