### PR TITLE
Support for non 16 MHz devices by adding extra parameter to constructor

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -6,9 +6,10 @@ written by Adafruit Industries
 
 #include "DHT.h"
 
-DHT::DHT(uint8_t pin, uint8_t type) {
+DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
   _pin = pin;
   _type = type;
+  _count = count;
   firstreading = true;
 }
 
@@ -129,7 +130,7 @@ boolean DHT::read(void) {
     if ((i >= 4) && (i%2 == 0)) {
       // shove each bit into the storage bytes
       data[j/8] <<= 1;
-      if (counter > 6)
+      if (counter > _count)
         data[j/8] |= 1;
       j++;
     }

--- a/DHT.h
+++ b/DHT.h
@@ -23,13 +23,13 @@ written by Adafruit Industries
 class DHT {
  private:
   uint8_t data[6];
-  uint8_t _pin, _type;
+  uint8_t _pin, _type, _count;
   boolean read(void);
   unsigned long _lastreadtime;
   boolean firstreading;
 
  public:
-  DHT(uint8_t pin, uint8_t type);
+  DHT(uint8_t pin, uint8_t type, uint8_t count=6);
   void begin(void);
   float readTemperature(bool S=false);
   float convertCtoF(float);


### PR DESCRIPTION
Added constructor parameter to allow for different timing needs. It has
the a default value of 6 which is the original value, so it should be
backwards compatible
