### PR TITLE
Comment Serial.print on read failure(s)

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -46,7 +46,9 @@ float DHT::readTemperature(bool S) {
       return f;
     }
   }
+  /*
   Serial.print("Read fail");
+  */
   return NAN;
 }
 
@@ -70,7 +72,9 @@ float DHT::readHumidity(void) {
       return f;
     }
   }
+  /*
   Serial.print("Read fail");
+  */
   return NAN;
 }
 


### PR DESCRIPTION
Allow callers to choose how to handle read failures.
