### PR TITLE
return correct success/failure flag for reads <2sec apart

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -11,6 +11,7 @@ DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
   _type = type;
   _count = count;
   firstreading = true;
+  _lastreadsucceeded = false;
 }
 
 void DHT::begin(void) {
@@ -24,7 +25,8 @@ void DHT::begin(void) {
 float DHT::readTemperature(bool S) {
   float f;
 
-  if (read()) {
+  _lastreadsucceeded = read();
+  if (_lastreadsucceeded) {
     switch (_type) {
     case DHT11:
       f = data[2];
@@ -59,7 +61,8 @@ float DHT::convertFtoC(float f) {
 
 float DHT::readHumidity(void) {
   float f;
-  if (read()) {
+  _lastreadsucceeded = read();
+  if (_lastreadsucceeded) {
     switch (_type) {
     case DHT11:
       f = data[0];
@@ -105,7 +108,7 @@ boolean DHT::read(void) {
     _lastreadtime = 0;
   }
   if (!firstreading && ((currenttime - _lastreadtime) < 2000)) {
-    return true; // return last correct measurement
+    return _lastreadsucceeded; // return last measurement
     //delay(2000 - (currenttime - _lastreadtime));
   }
   firstreading = false;

--- a/DHT.h
+++ b/DHT.h
@@ -26,6 +26,7 @@ class DHT {
   uint8_t _pin, _type, _count;
   unsigned long _lastreadtime;
   boolean firstreading;
+  boolean _lastreadsucceeded;
 
  public:
   DHT(uint8_t pin, uint8_t type, uint8_t count=6);


### PR DESCRIPTION
This is a fix for an issue that I encountered while using this library in a project where I need to be sure I can detect failed readings.

Previously, if the sensor was read N times within 2 seconds, the read method always returned true for reads #2-N regardless of whether read #1 had succeeded. Thus, when read #1 had failed, the subsequent reads would still "succeed" and return zeroes rather than NANs. Since 0° can also be a legitimate temperature, this makes it difficult to filter out false readings.

You can see the issue by:
* commenting out lines 51 to 54 in the example code (the part that returns early after any failure), or replacing the ||s in line 51 with &&s
* running it with the sensor unplugged

Before the patch: the first reading (humidity) correctly prints NAN, but the two temperature values print 0 and 32 respectively
After the patch: all three measures correctly print NAN

Thanks!