### PR TITLE
Cause interrupts to be reenabled if a timeout occurs while waiting for the sensor

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -57,4 +57,15 @@ class DHT {
 
 };
 
+class InterruptLock {
+  public:
+   InterruptLock() {
+    noInterrupts();
+   }
+   ~InterruptLock() {
+    interrupts();
+   }
+
+};
+
 #endif


### PR DESCRIPTION
Sorry for the commit noise here. This commit addresses an issue I saw while looking at the code where if a sensor timeout occurs for whatever reason, interrupts will not be reenabled.