### PR TITLE
Allow forcing a read and a few fixes

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -21,8 +21,7 @@ DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
 
 void DHT::begin(void) {
   // set up the pins!
-  pinMode(_pin, INPUT);
-  digitalWrite(_pin, HIGH);
+  pinMode(_pin, INPUT_PULLUP);
   // Using this value makes sure that millis() - lastreadtime will be
   // >= MIN_INTERVAL right away. Note that this assignment wraps around,
   // but so will the subtraction.
@@ -153,7 +152,7 @@ boolean DHT::read(bool force) {
     delayMicroseconds(40);
 
     // Now start reading the data line to get the value from the DHT sensor.
-    pinMode(_pin, INPUT);
+    pinMode(_pin, INPUT_PULLUP);
     delayMicroseconds(10);  // Delay a bit to let sensor pull data line low.
 
     // First expect a low signal for ~80 microseconds followed by a high signal

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -117,15 +117,11 @@ boolean DHT::read(bool force) {
   // Check if sensor was read less than two seconds ago and return early
   // to use last reading.
   uint32_t currenttime = millis();
-  if (currenttime < _lastreadtime) {
-    // ie there was a rollover
-    _lastreadtime = 0;
-  }
   if (!force && !_firstreading && ((currenttime - _lastreadtime) < 2000)) {
     return _lastresult; // return last correct measurement
   }
   _firstreading = false;
-  _lastreadtime = millis();
+  _lastreadtime = currenttime;
 
   // Reset 40 bits of received data to zero.
   data[0] = data[1] = data[2] = data[3] = data[4] = 0;

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -27,10 +27,10 @@ void DHT::begin(void) {
 }
 
 //boolean S == Scale.  True == Fahrenheit; False == Celcius
-float DHT::readTemperature(bool S) {
+float DHT::readTemperature(bool S, bool force) {
   float f = NAN;
 
-  if (read()) {
+  if (read(force)) {
     switch (_type) {
     case DHT11:
       f = data[2];
@@ -64,7 +64,7 @@ float DHT::convertFtoC(float f) {
   return (f - 32) * 5 / 9;
 }
 
-float DHT::readHumidity(void) {
+float DHT::readHumidity(bool force) {
   float f = NAN;
   if (read()) {
     switch (_type) {
@@ -113,7 +113,7 @@ float DHT::computeHeatIndex(float temperature, float percentHumidity, bool isFah
   }
 }
 
-boolean DHT::read(void) {
+boolean DHT::read(bool force) {
   // Check if sensor was read less than two seconds ago and return early
   // to use last reading.
   uint32_t currenttime = millis();
@@ -121,7 +121,7 @@ boolean DHT::read(void) {
     // ie there was a rollover
     _lastreadtime = 0;
   }
-  if (!_firstreading && ((currenttime - _lastreadtime) < 2000)) {
+  if (!force && !_firstreading && ((currenttime - _lastreadtime) < 2000)) {
     return _lastresult; // return last correct measurement
   }
   _firstreading = false;

--- a/DHT.h
+++ b/DHT.h
@@ -47,7 +47,7 @@ class DHT {
    boolean read(bool force=false);
 
  private:
-  uint8_t data[6];
+  uint8_t data[5];
   uint8_t _pin, _type, _bit, _port;
   uint32_t _lastreadtime, _maxcycles;
   bool _lastresult;

--- a/DHT.h
+++ b/DHT.h
@@ -50,7 +50,6 @@ class DHT {
   uint8_t data[6];
   uint8_t _pin, _type, _bit, _port;
   uint32_t _lastreadtime, _maxcycles;
-  bool _firstreading;
   bool _lastresult;
 
   uint32_t expectPulse(bool level);

--- a/DHT.h
+++ b/DHT.h
@@ -39,12 +39,12 @@ class DHT {
   public:
    DHT(uint8_t pin, uint8_t type, uint8_t count=6);
    void begin(void);
-   float readTemperature(bool S=false);
+   float readTemperature(bool S=false, bool force=false);
    float convertCtoF(float);
    float convertFtoC(float);
    float computeHeatIndex(float temperature, float percentHumidity, bool isFahrenheit=true);
-   float readHumidity(void);
-   boolean read(void);
+   float readHumidity(bool force=false);
+   boolean read(bool force=false);
 
  private:
   uint8_t data[6];


### PR DESCRIPTION
I've found that when the Arduino employs sleeping, it can no longer properly read the sensor since millis() doesn't tick while sleeping (and the library now *insists* that the Arduino has been *awake* for 2 seconds since the last reading). I fixed this by adding a "force" parameter to the read methods.

While I was there, I did a few more cleanups of some code I encountered along the way, which should slightly simplify and shrink things (without losing any functionality).