### PR TITLE
A more accurate DHT::computeHeatIndex implementation

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -109,10 +109,10 @@ float DHT::computeHeatIndex(float temperature, float percentHumidity, bool isFah
             -0.00000199 * pow(temperature, 2) * pow(percentHumidity, 2);
 
     if((percentHumidity < 13) && (temperature >= 80.0) && (temperature <= 112.0))
-      hi -= ((13.0 - percentHumidity) / 4.0) * sqrt((17.0 - abs(temperature - 95.0))/17.0);
+      hi -= ((13.0 - percentHumidity) * 0.25) * sqrt((17.0 - abs(temperature - 95.0)) * 0.05882);
 
     else if((percentHumidity > 85.0) && (temperature >= 80.0) && (temperature <= 87.0))
-      hi += ((percentHumidity - 85.0) / 10.0) * ((87.0 - temperature)/5.0);
+      hi += ((percentHumidity - 85.0) * 0.1) * ((87.0 - temperature) * 0.2);
   }
 
   return isFahrenheit ? hi : convertFtoC(hi);

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -88,23 +88,17 @@ float DHT::readHumidity(bool force) {
 
 //boolean isFahrenheit: True == Fahrenheit; False == Celcius
 float DHT::computeHeatIndex(float temperature, float percentHumidity, bool isFahrenheit) {
-  // Adapted from equation at: https://github.com/adafruit/DHT-sensor-library/issues/9 and
-  // Wikipedia: http://en.wikipedia.org/wiki/Heat_index
-  if (!isFahrenheit) {
-    // Celsius heat index calculation.
-    return -8.784695 +
-             1.61139411 * temperature +
-             2.338549   * percentHumidity +
-            -0.14611605 * temperature*percentHumidity +
-            -0.01230809 * pow(temperature, 2) +
-            -0.01642482 * pow(percentHumidity, 2) +
-             0.00221173 * pow(temperature, 2) * percentHumidity +
-             0.00072546 * temperature*pow(percentHumidity, 2) +
-            -0.00000358 * pow(temperature, 2) * pow(percentHumidity, 2);
-  }
-  else {
-    // Fahrenheit heat index calculation.
-    return -42.379 +
+  // Using both Rothfusz and Steadman's equations
+  // http://www.wpc.ncep.noaa.gov/html/heatindex_equation.shtml
+  float hi;
+
+  if (!isFahrenheit)
+    temperature = convertCtoF(temperature);
+
+  hi = 0.5 * (temperature + 61.0 + ((temperature - 68.0) * 1.2) + (percentHumidity * 0.094)); 
+
+  if (hi > 79) {
+    hi = -42.379 +
              2.04901523 * temperature +
             10.14333127 * percentHumidity +
             -0.22475541 * temperature*percentHumidity +
@@ -113,7 +107,15 @@ float DHT::computeHeatIndex(float temperature, float percentHumidity, bool isFah
              0.00122874 * pow(temperature, 2) * percentHumidity +
              0.00085282 * temperature*pow(percentHumidity, 2) +
             -0.00000199 * pow(temperature, 2) * pow(percentHumidity, 2);
+
+    if((percentHumidity < 13) && (temperature >= 80.0) && (temperature <= 112.0))
+      hi -= ((13.0 - percentHumidity) / 4.0) * sqrt((17.0 - abs(temperature - 95.0))/17.0);
+
+    else if((percentHumidity > 85.0) && (temperature >= 80.0) && (temperature <= 87.0))
+      hi += ((percentHumidity - 85.0) / 10.0) * ((87.0 - temperature)/5.0);
   }
+
+  return isFahrenheit ? hi : convertFtoC(hi);
 }
 
 boolean DHT::read(bool force) {


### PR DESCRIPTION
DHT::computeHeatIndex has been modified so it uses both Rothfusz and Steadman's equations. 

As a result, it allows a larger range of temperatures and more accurate results for extreme conditions.

See: http://www.wpc.ncep.noaa.gov/html/heatindex_equation.shtml
