### PR TITLE
Removed "End the start signal by setting data line high for 40 micros…

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -152,9 +152,13 @@ boolean DHT::read(bool force) {
     InterruptLock lock;
 
     // End the start signal by setting data line high for 40 microseconds.
-    digitalWrite(_pin, HIGH);
-    delayMicroseconds(40);
-
+    // digitalWrite(_pin, HIGH);
+    // delayMicroseconds(40);
+    // WEB: This is an error. DHT tries to pull the line low as soon as it came back to high.
+    // therefore the low-high transition after the start signal "low" needs to be realised by
+    // the pullup resistor only, uC pin must already be in INPUT mode.
+    // ref: https://github.com/adafruit/DHT-sensor-library/issues/48#issue-119801608
+    
     // Now start reading the data line to get the value from the DHT sensor.
     pinMode(_pin, INPUT_PULLUP);
     delayMicroseconds(10);  // Delay a bit to let sensor pull data line low.


### PR DESCRIPTION
…econds"

Reference: https://github.com/adafruit/DHT-sensor-library/issues/48#issue-119801608

@W-H many thanks for this fix!
