### PR TITLE
Added Convenience Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Vi files
+*~
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -8,26 +8,16 @@ written by Adafruit Industries
 
 #define MIN_INTERVAL 2000
 
-/*
- * Old constructor left in for backwards compatability.
- */
-DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
-  DHT::_init(pin, type);
-  // Note that count is now ignored as the DHT reading algorithm adjusts itself
-  // based on the speed of the processor.
-}
+// Old constructor.
+//DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
 
 /*
  * New constructor.
+ *
+ * Note that count is now ignored as the DHT reading algorithm adjusts itself
+ * based on the speed of the processor.
  */
 DHT::DHT(uint8_t pin, uint8_t type) {
-  DHT::_init(pin, type);
-}
-
-/*
- * Common class initialization code.
- */
-void DHT::_init(uint8_t pin, uint8_t type) {
   _pin = pin;
   _type = type;
   #ifdef __AVR

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -8,7 +8,26 @@ written by Adafruit Industries
 
 #define MIN_INTERVAL 2000
 
+/*
+ * Old constructor left in for backwards compatability.
+ */
 DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
+  DHT::_init(pin, type);
+  // Note that count is now ignored as the DHT reading algorithm adjusts itself
+  // based on the speed of the processor.
+}
+
+/*
+ * New constructor.
+ */
+DHT::DHT(uint8_t pin, uint8_t type) {
+  DHT::_init(pin, type);
+}
+
+/*
+ * Common class initialization code.
+ */
+void DHT::_init(uint8_t pin, uint8_t type) {
   _pin = pin;
   _type = type;
   #ifdef __AVR
@@ -17,9 +36,8 @@ DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
   #endif
   _maxcycles = microsecondsToClockCycles(1000);  // 1 millisecond timeout for
                                                  // reading pulses from DHT sensor.
-  // Note that count is now ignored as the DHT reading algorithm adjusts itself
-  // basd on the speed of the processor.
 }
+
 
 void DHT::begin(void) {
   // set up the pins!

--- a/DHT.h
+++ b/DHT.h
@@ -37,7 +37,11 @@ written by Adafruit Industries
 
 class DHT {
   public:
-   DHT(uint8_t pin, uint8_t type, uint8_t count=6);
+   // Note that count is now ignored as the DHT reading algorithm adjusts itself
+   // based on the speed of the processor.
+   DHT(uint8_t pin, uint8_t type, uint8_t count) {
+     DHT(pin, type);
+   };
    DHT(uint8_t pin, uint8_t type);
    void begin(void);
    float readTemperature(bool S=false, bool force=false);

--- a/DHT.h
+++ b/DHT.h
@@ -38,6 +38,7 @@ written by Adafruit Industries
 class DHT {
   public:
    DHT(uint8_t pin, uint8_t type, uint8_t count=6);
+   DHT(uint8_t pin, uint8_t type);
    void begin(void);
    float readTemperature(bool S=false, bool force=false);
    float convertCtoF(float);
@@ -59,6 +60,7 @@ class DHT {
 
   uint32_t expectPulse(bool level);
 
+  void _init(uint8_t pin, uint8_t type);
 };
 
 class InterruptLock {

--- a/DHT.h
+++ b/DHT.h
@@ -44,9 +44,21 @@ class DHT {
    };
    DHT(uint8_t pin, uint8_t type);
    void begin(void);
+   float readFahrenheit(bool force=false) {
+       return readTemperature(true, force);
+   };
+   float readCelcius(bool force=false) {
+       return readTemperature(false, force);
+   };
    float readTemperature(bool S=false, bool force=false);
    float convertCtoF(float);
    float convertFtoC(float);
+   float computeHeatIndexFahrenheit(float temperature, float percentHumidity) {
+       return computeHeatIndex(temperature, percentHumidity, true);
+   };
+   float computeHeatIndexCelcius(float temperature, float percentHumidity) {
+       return computeHeatIndex(temperature, percentHumidity, false);
+   };
    float computeHeatIndex(float temperature, float percentHumidity, bool isFahrenheit=true);
    float readHumidity(bool force=false);
    boolean read(bool force=false);


### PR DESCRIPTION
I added some convenience methods to the library while maintaining backwards compatibility. 
There are now methods in DHT.h with Celsius and Fahrenheit in the method names which in turn call the existing methods with the boolean flag set accordingly.  This makes the calling program easier to read and reduces confusion around what the flag means without having to look at the library each time.

I also removed count from the constructor in DHT.cpp.  For backwards compatibility, I added a overload in DHT.h that accepts it, ignores it, and calls the constructor without it.
