### PR TITLE
Start listening to the sensor right after releasing the start signal …

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -135,11 +135,6 @@ boolean DHT::read(bool force) {
   // Send start signal.  See DHT datasheet for full signal diagram:
   //   http://www.adafruit.com/datasheets/Digital%20humidity%20and%20temperature%20sensor%20AM2302.pdf
 
-  // Go into high impedence state to let pull-up raise data line level and
-  // start the reading process.
-  digitalWrite(_pin, HIGH);
-  delay(250);
-
   // First set data line low for 20 milliseconds.
   pinMode(_pin, OUTPUT);
   digitalWrite(_pin, LOW);
@@ -149,23 +144,42 @@ boolean DHT::read(bool force) {
   {
     // Turn off interrupts temporarily because the next sections are timing critical
     // and we don't want any interruptions.
+    // NOTE: From this point we cannot use function such as delay(), delayMicroseconds(), 
+    //       Those functions among others rely on interrupts.  
     InterruptLock lock;
 
-    // End the start signal by setting data line high for 40 microseconds.
-    digitalWrite(_pin, HIGH);
-    delayMicroseconds(40);
-
+    // End of the start signal.
     // Now start reading the data line to get the value from the DHT sensor.
     pinMode(_pin, INPUT_PULLUP);
-    delayMicroseconds(10);  // Delay a bit to let sensor pull data line low.
+    // from this point we listen, it's sensor's turn to talk.  
 
-    // First expect a low signal for ~80 microseconds followed by a high signal
-    // for ~80 microseconds again.
+
+    // The following step is a busy-wait loop to continue only 
+    // when the data line has been pulled LOW by the sensor.  
+    //
+    // To avoid infinite loops here, we use a counter as a timeout.
+    // 700 iterations is about 4 ms on a 16Mhz processor.  The sensor should
+    // set the pin LOW within 20 to 40 microseconds.
+    // The (F_CPU / 16000000) is a ratio to keep the timeout to approximately
+    // the same period if processor used has different frequency.
+    unsigned long timesup = (F_CPU / 16000000) * 700;  
+    unsigned long count = 0;
+    while (digitalRead(_pin) == HIGH && ++count < timesup)
+        ;
+    if (count == timesup) {
+      DEBUG_PRINTLN(F("Timeout waiting sensor to pull the data line LOW."));
+      _lastresult = false;
+      return _lastresult;
+    }
+
+    // expect a low signal for ~80 microseconds. 
     if (expectPulse(LOW) == 0) {
       DEBUG_PRINTLN(F("Timeout waiting for start signal low pulse."));
       _lastresult = false;
       return _lastresult;
     }
+    
+    // followed by a high signal for ~80 microseconds.
     if (expectPulse(HIGH) == 0) {
       DEBUG_PRINTLN(F("Timeout waiting for start signal high pulse."));
       _lastresult = false;
@@ -184,7 +198,8 @@ boolean DHT::read(bool force) {
       cycles[i]   = expectPulse(LOW);
       cycles[i+1] = expectPulse(HIGH);
     }
-  } // Timing critical code is now complete.
+    // Interrupts will turn back on when exiting this scope.
+  } // Timing critical code is now complete.  
 
   // Inspect pulses and determine which ones are 0 (high state cycle count < low
   // state cycle count), or 1 (high state cycle count > low state cycle count).


### PR DESCRIPTION
Hi all,

Here is my pull request for the changes I have done relate to how the library sends the start signal to the sensor and the hope is it will solve and that it will have the effect of a closed #48.  It also relates to PR #51 and PR #58.

  - Firstly, there is an unnecessary wait of 250ms before the start signal.  This is the reason I started to look at fixing the init sequence.  I remember reading that it could be needed by those not using a pull up, in 85a02c70fb32c351f8cac71ecf8961d704b39fa4.  ( If that were the case, the pin is set HIGH in begin(), it could be set again before exiting the read method.  The pin state should stay HIGH as no other read can be made in the following two seconds, so more than enough time to cover that 250ms that I would like to have removed.  We would also need to make sure the first read is done after proper period if sensor needs time to wake up upon start. )

  - Second, from what I conclude after a read of the datasheet and from what I have read on several forums, the MCU should only pull the line LOW for a period of time and then leave the line to the sensor.  There is a possible variable amount of time before  the sensor will signal its LOW and HIGH for ~80us each while preparing the data.  This part
was changed for a busy-wait loop to ensure the library gets it at a correct time and not have the guess the wait period for all possible sensors.  This has made the delayMicroseconds() calls redundant.  That should also satisfy the change that was originally suggested by Wolfgang and referenced in 5ed981893ccf66c886214c2863f0d4482af27bbd.

The changes' goal is to ensure the MCU and sensor do not talk at the same time.  A few comments were also added to support the code changes.

Thank you,

Pascal
