### PR TITLE
add begin() with device type, so device type can be set in SETUP() after being read from a config source

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -21,6 +21,7 @@ DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
   // basd on the speed of the processor.
 }
 
+//add begin with device type, so device type can be set in SETUP() after being read from a config source
 void DHT::begin(uint8_t type) {
   // set up the pins!
   pinMode(_pin, INPUT_PULLUP);

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -21,6 +21,18 @@ DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
   // basd on the speed of the processor.
 }
 
+void DHT::begin(uint8_t type) {
+  // set up the pins!
+  pinMode(_pin, INPUT_PULLUP);
+  _type = type;
+  // Using this value makes sure that millis() - lastreadtime will be
+  // >= MIN_INTERVAL right away. Note that this assignment wraps around,
+  // but so will the subtraction.
+  _lastreadtime = -MIN_INTERVAL;
+  DEBUG_PRINT("Max clock cycles: "); DEBUG_PRINTLN(_maxcycles, DEC);
+}
+
+
 void DHT::begin(void) {
   // set up the pins!
   pinMode(_pin, INPUT_PULLUP);
@@ -30,6 +42,8 @@ void DHT::begin(void) {
   _lastreadtime = -MIN_INTERVAL;
   DEBUG_PRINT("Max clock cycles: "); DEBUG_PRINTLN(_maxcycles, DEC);
 }
+
+
 
 //boolean S == Scale.  True == Fahrenheit; False == Celcius
 float DHT::readTemperature(bool S, bool force) {

--- a/DHT.h
+++ b/DHT.h
@@ -39,7 +39,7 @@ class DHT {
   public:
    DHT(uint8_t pin, uint8_t type, uint8_t count=6);
    void begin(void);
-   void DHT::begin(uint8_t type);
+   void begin(uint8_t type);
    float readTemperature(bool S=false, bool force=false);
    float convertCtoF(float);
    float convertFtoC(float);

--- a/DHT.h
+++ b/DHT.h
@@ -39,6 +39,7 @@ class DHT {
   public:
    DHT(uint8_t pin, uint8_t type, uint8_t count=6);
    void begin(void);
+//add begin with device type, so device type can be set in SETUP() after being read from a config source
    void begin(uint8_t type);
    float readTemperature(bool S=false, bool force=false);
    float convertCtoF(float);

--- a/DHT.h
+++ b/DHT.h
@@ -39,6 +39,7 @@ class DHT {
   public:
    DHT(uint8_t pin, uint8_t type, uint8_t count=6);
    void begin(void);
+   void DHT::begin(uint8_t type);
    float readTemperature(bool S=false, bool force=false);
    float convertCtoF(float);
    float convertFtoC(float);

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ which is designed to work with the [Adafruit unified sensor library](https://lea
 You must have the following Arduino libraries installed to use this class:
 
 - [Adafruit Unified Sensor Library](https://github.com/adafruit/Adafruit_Sensor)
+
+
+ADD Ability to change sensor type after instantiation for use with a configuration PCB i am developing
+void DHT::begin(uint8_t type);

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ You must have the following Arduino libraries installed to use this class:
 - [Adafruit Unified Sensor Library](https://github.com/adafruit/Adafruit_Sensor)
 
 
-ADD Ability to change sensor type after instantiation for use with a configuration PCB i am developing
+ADD Ability to change sensor type after instantiation for use with a configuraable PCB i am developing
 void DHT::begin(uint8_t type);


### PR DESCRIPTION
really simple change to support my use case

i have a ESP8266 board which i plan to fit DHT11 or DHT22 to, the type will vary depending on use, 
rather than recompile my code each time, i need to be able to set the device type at runtime (via a configuration file (SPIFFS), web page on ESP8266) not design time

adding an additional constructor which does not require type to be specified 
adding an additional begin() which accepts device type 

achieves this, as it allows me to set the device type in the setup section after fetching and configuration from SPIFFS

[DHT.zip](https://github.com/adafruit/DHT-sensor-library/files/1067460/DHT.zip)



