### PR TITLE
Fixes #81 Distinguish "signal already there" from "timeout"

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -7,6 +7,7 @@ written by Adafruit Industries
 #include "DHT.h"
 
 #define MIN_INTERVAL 2000
+#define TIMEOUT -1
 
 DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
   _pin = pin;
@@ -161,12 +162,12 @@ boolean DHT::read(bool force) {
 
     // First expect a low signal for ~80 microseconds followed by a high signal
     // for ~80 microseconds again.
-    if (expectPulse(LOW) == 0) {
+    if (expectPulse(LOW) == TIMEOUT) {
       DEBUG_PRINTLN(F("Timeout waiting for start signal low pulse."));
       _lastresult = false;
       return _lastresult;
     }
-    if (expectPulse(HIGH) == 0) {
+    if (expectPulse(HIGH) == TIMEOUT) {
       DEBUG_PRINTLN(F("Timeout waiting for start signal high pulse."));
       _lastresult = false;
       return _lastresult;
@@ -191,7 +192,7 @@ boolean DHT::read(bool force) {
   for (int i=0; i<40; ++i) {
     uint32_t lowCycles  = cycles[2*i];
     uint32_t highCycles = cycles[2*i+1];
-    if ((lowCycles == 0) || (highCycles == 0)) {
+    if ((lowCycles == TIMEOUT) || (highCycles == TIMEOUT)) {
       DEBUG_PRINTLN(F("Timeout waiting for pulse."));
       _lastresult = false;
       return _lastresult;
@@ -242,7 +243,7 @@ uint32_t DHT::expectPulse(bool level) {
     uint8_t portState = level ? _bit : 0;
     while ((*portInputRegister(_port) & _bit) == portState) {
       if (count++ >= _maxcycles) {
-        return 0; // Exceeded timeout, fail.
+        return TIMEOUT; // Exceeded timeout, fail.
       }
     }
   // Otherwise fall back to using digitalRead (this seems to be necessary on ESP8266
@@ -250,7 +251,7 @@ uint32_t DHT::expectPulse(bool level) {
   #else
     while (digitalRead(_pin) == level) {
       if (count++ >= _maxcycles) {
-        return 0; // Exceeded timeout, fail.
+        return TIMEOUT; // Exceeded timeout, fail.
       }
     }
   #endif


### PR DESCRIPTION
If expectPulse(LOW) sees the port is already LOW (result == 0), this is not timeout!

See Issue #81 
We set the pin high and wait 40+10=50 microsec. After such time the sensor could already has set the data line to 0. Than `if (expectPulse(LOW) == 0)` in line 164 returns 0 because the line is already LOW; the library ignores the message from the sensor, prints `"Timeout waiting for start signal low pulse."` and returns with `nan`.

With this change, `DHT::expectPulse(bool level)` will return "0xFFFFFFFF" ("-1") in case of timeout.