### PR TITLE
Fix api inconsistency about temperature units

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -31,15 +31,15 @@ void DHT::begin(void) {
   DEBUG_PRINT("Max clock cycles: "); DEBUG_PRINTLN(_maxcycles, DEC);
 }
 
-//boolean S == Scale.  True == Fahrenheit; False == Celcius
-float DHT::readTemperature(bool S, bool force) {
+//boolean isFahrenheit: True == Fahrenheit; False == Celcius
+float DHT::readTemperature(bool isFahrenheit, bool force) {
   float f = NAN;
 
   if (read(force)) {
     switch (_type) {
     case DHT11:
       f = data[2];
-      if(S) {
+      if(isFahrenheit) {
         f = convertCtoF(f);
       }
       break;
@@ -52,7 +52,7 @@ float DHT::readTemperature(bool S, bool force) {
       if (data[2] & 0x80) {
         f *= -1;
       }
-      if(S) {
+      if(isFahrenheit) {
         f = convertCtoF(f);
       }
       break;

--- a/DHT.h
+++ b/DHT.h
@@ -42,7 +42,7 @@ class DHT {
    float readTemperature(bool S=false, bool force=false);
    float convertCtoF(float);
    float convertFtoC(float);
-   float computeHeatIndex(float temperature, float percentHumidity, bool isFahrenheit=true);
+   float computeHeatIndex(float temperature, float percentHumidity, bool isFahrenheit=false);
    float readHumidity(bool force=false);
    boolean read(bool force=false);
 

--- a/DHT.h
+++ b/DHT.h
@@ -39,7 +39,7 @@ class DHT {
   public:
    DHT(uint8_t pin, uint8_t type, uint8_t count=6);
    void begin(void);
-   float readTemperature(bool S=false, bool force=false);
+   float readTemperature(bool isFahrenheit=false, bool force=false);
    float convertCtoF(float);
    float convertFtoC(float);
    float computeHeatIndex(float temperature, float percentHumidity, bool isFahrenheit=false);

--- a/examples/DHTtester/DHTtester.ino
+++ b/examples/DHTtester/DHTtester.ino
@@ -48,10 +48,10 @@ void loop() {
     return;
   }
 
-  // Compute heat index in Fahrenheit (the default)
-  float hif = dht.computeHeatIndex(f, h);
-  // Compute heat index in Celsius (isFahreheit = false)
-  float hic = dht.computeHeatIndex(t, h, false);
+  // Compute heat index in Celsius (the default)
+  float hif = dht.computeHeatIndex(t, h);
+  // Compute heat index in Fahrenheit (isFahreheit = true)
+  float hic = dht.computeHeatIndex(f, h, true);
 
   Serial.print("Humidity: ");
   Serial.print(h);


### PR DESCRIPTION
# Problem

When we read temperature the default units are Celsius and to get Fahrenheit we need to pass an additional flag. On the other hand heat index is calculated in Fahrenheit by default and there is a need to pass an additional boolean flag to retrieve a value in Celsius. See snipter/firebase-iot-codelab#3.

# Description

This PR fixes the inconsistency by setting the default units to Celsius. Alongside this a little naming improvement has been done to make the purpose of flags in `readTemperature` more clear.

# Limitations

Introduced changes are API-breaking, so a major version should be incremented in the release which will contain this patch.