### PR TITLE
Use micros() instead of cycle counting.

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -64,6 +64,8 @@ class DHT {
 class InterruptLock {
   public:
    InterruptLock() {
+    // This is a nop on my esp32 Arduino system. noInterrupts() is defined to
+    // cli(), which is empty.
     noInterrupts();
    }
    ~InterruptLock() {


### PR DESCRIPTION
In the ESP32 Arduino library, noInterrupts() is a nop, so interrupts
still occur while receiving a value. On my board there is at least one
interrupt every time we try to read a value, which messes up the
reading. Instead of counting cycles, use micros() to keep track of time.
This increases the success rate of receiving data to 90% or so.

A better fix would be to implement noInterrupts() for the ESP32, but
that looks a lot harder. The new code path is probably not suitable for
slower micros, but hopefully those use the __AVR code path anyway.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

I'm not sure this should be merged as-is, but I want it to be available to people who are running into the same problem.