### PR TITLE
Add support for DHT12.

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -38,7 +38,12 @@ float DHT::readTemperature(bool S, bool force) {
   if (read(force)) {
     switch (_type) {
     case DHT11:
+    case DHT12:
       f = data[2];
+      f += (data[3] & 0x0f) * 0.1;
+      if (data[2] & 0x80) {
+        f *= -1;
+      }
       if(S) {
         f = convertCtoF(f);
       }
@@ -74,7 +79,8 @@ float DHT::readHumidity(bool force) {
   if (read()) {
     switch (_type) {
     case DHT11:
-      f = data[0];
+    case DHT12:
+      f = data[0] + data[1] * 0.1;
       break;
     case DHT22:
     case DHT21:

--- a/DHT.h
+++ b/DHT.h
@@ -30,6 +30,7 @@ written by Adafruit Industries
 
 // Define types of sensors.
 #define DHT11 11
+#define DHT12 12
 #define DHT22 22
 #define DHT21 21
 #define AM2301 21

--- a/DHT_U.cpp
+++ b/DHT_U.cpp
@@ -37,6 +37,9 @@ void DHT_Unified::setName(sensor_t* sensor) {
     case DHT11:
       strncpy(sensor->name, "DHT11", sizeof(sensor->name) - 1);
       break;
+    case DHT12:
+      strncpy(sensor->name, "DHT12", sizeof(sensor->name) - 1);
+      break;
     case DHT21:
       strncpy(sensor->name, "DHT21", sizeof(sensor->name) - 1);
       break;
@@ -56,6 +59,9 @@ void DHT_Unified::setMinDelay(sensor_t* sensor) {
   switch(_type) {
     case DHT11:
       sensor->min_delay = 1000000L;  // 1 second (in microseconds)
+      break;
+    case DHT12:
+      sensor->min_delay = 2000000L;  // 1 second (in microseconds)
       break;
     case DHT21:
       sensor->min_delay = 2000000L;  // 2 seconds (in microseconds)
@@ -104,6 +110,11 @@ void DHT_Unified::Temperature::getSensor(sensor_t* sensor) {
       sensor->max_value   = 50.0F;
       sensor->min_value   = 0.0F;
       sensor->resolution  = 2.0F;
+      break;
+    case DHT12:
+      sensor->max_value   = 60.0F;
+      sensor->min_value   = -20.0F;
+      sensor->resolution  = 0.5F;
       break;
     case DHT21:
       sensor->max_value   = 80.0F;
@@ -156,6 +167,11 @@ void DHT_Unified::Humidity::getSensor(sensor_t* sensor) {
   switch (_parent->_type) {
     case DHT11:
       sensor->max_value   = 80.0F;
+      sensor->min_value   = 20.0F;
+      sensor->resolution  = 5.0F;
+      break;
+    case DHT12:
+      sensor->max_value   = 95.0F;
       sensor->min_value   = 20.0F;
       sensor->resolution  = 5.0F;
       break;

--- a/DHT_U.cpp
+++ b/DHT_U.cpp
@@ -61,7 +61,7 @@ void DHT_Unified::setMinDelay(sensor_t* sensor) {
       sensor->min_delay = 1000000L;  // 1 second (in microseconds)
       break;
     case DHT12:
-      sensor->min_delay = 2000000L;  // 1 second (in microseconds)
+      sensor->min_delay = 2000000L;  // 2 second (in microseconds)
       break;
     case DHT21:
       sensor->min_delay = 2000000L;  // 2 seconds (in microseconds)


### PR DESCRIPTION
Add support for DHT12.
Change DHT11 temperature resolution to 0.1 instead of 1.

DHT12 using almost same data structure as DHT11.
The DHT11 sensor can report temperature at 0.1 resolution. Maybe it is not that accumulate, but it should works for checking temperature changes.