### PR TITLE
Making the library work nicely with the nrf52

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -64,10 +64,14 @@ class DHT {
 class InterruptLock {
   public:
    InterruptLock() {
+#if !defined(ARDUINO_ARCH_NRF52)  
     noInterrupts();
+#endif
    }
    ~InterruptLock() {
+#if !defined(ARDUINO_ARCH_NRF52)  
     interrupts();
+#endif
    }
 
 };


### PR DESCRIPTION
This change makes it possible to use the library with the nrf52 processor.

I'm trying to use the DHT22 sensor with the nrf52 feather and if the interrupts are turned off and on the program locks up while inside a delay call. Running the example code doesn't lock it but with more complex code, especially with more bluetooth code it locks up unexpectedly.

Leaving interrupts enabled all the time works for me. It does miss a few readings every once in a while but it's very rare.

If you need some test code this should make it lock up without my changes: https://github.com/gpambrozio/arduino/blob/efa696d7ddde092857829e143db9a77a5545db95/agnes_thermostat/agnes_thermostat.ino