### PR TITLE
removed double conversion to Celsius

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -107,7 +107,7 @@ float DHT::readHumidity(bool force) {
 float DHT::computeHeatIndex(bool isFahrenheit) {
   float hi = computeHeatIndex(readTemperature(isFahrenheit), readHumidity(),
     isFahrenheit);
-  return isFahrenheit ? hi : convertFtoC(hi);
+  return hi;
 }
 
 //boolean isFahrenheit: True == Fahrenheit; False == Celcius


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  
In computeHeatIndex(bool isFahrenheit) the heatIndex is converted to Celsius, but it was already converted in the called function computeHeatIndex(float temperature, float percentHumidity, bool isFahrenheit). The heatIndex in Celsius will be converted twice, resulting in a wrong value.

- **Describe any known limitations with your change.** 
Will break the interface for users already fixing this bug in their code.

- **Please run any tests or examples that can exercise your modified code.**  
n/a

