### PR TITLE
Better handle the case where begin() isn't called before read().

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -66,7 +66,7 @@ void DHT::begin(uint8_t usec) {
   _lastreadtime = millis() - MIN_INTERVAL;
   DEBUG_PRINT("DHT max clock cycles: ");
   DEBUG_PRINTLN(_maxcycles, DEC);
-  pullTime = usec;
+  _pullTime = usec;
 }
 
 /*!
@@ -234,6 +234,12 @@ bool DHT::read(bool force) {
   }
   _lastreadtime = currenttime;
 
+  // Make sure begin() was called.
+  if (_pullTime < 1) {
+    DEBUG_PRINTLN(F("read() was incorrectly called before begin()"));
+    _pullTime = DEFAULT_PULLTIME;
+  }
+
   // Reset 40 bits of received data to zero.
   data[0] = data[1] = data[2] = data[3] = data[4] = 0;
 
@@ -269,7 +275,7 @@ bool DHT::read(bool force) {
     pinMode(_pin, INPUT_PULLUP);
 
     // Delay a moment to let sensor pull data line low.
-    delayMicroseconds(pullTime);
+    delayMicroseconds(_pullTime);
 
     // Now start reading the data line to get the value from the DHT sensor.
 

--- a/DHT.h
+++ b/DHT.h
@@ -41,6 +41,10 @@
 #define DHT21 21 /**< DHT TYPE 21 */
 #define AM2301 21 /**< AM2301 */
 
+/*!
+ *  Default time in usec to pull up the data line before reading from
+ *  the DHT. This can be overriden with the value passed into begin().
+ */
 #define DEFAULT_PULLTIME 55
 
 /*!

--- a/DHT.h
+++ b/DHT.h
@@ -41,13 +41,15 @@
 #define DHT21 21 /**< DHT TYPE 21 */
 #define AM2301 21 /**< AM2301 */
 
-/*! 
+#define DEFAULT_PULLTIME 55
+
+/*!
  *  @brief  Class that stores state and functions for DHT
  */
 class DHT {
   public:
    DHT(uint8_t pin, uint8_t type, uint8_t count=6);
-   void begin(uint8_t usec=55);
+   void begin(uint8_t usec=DEFAULT_PULLTIME);
    float readTemperature(bool S=false, bool force=false);
    float convertCtoF(float);
    float convertFtoC(float);
@@ -66,7 +68,7 @@ class DHT {
   #endif
   uint32_t _lastreadtime, _maxcycles;
   bool _lastresult;
-  uint8_t pullTime; // Time (in usec) to pull up data line before reading
+  uint8_t _pullTime; // Time (in usec) to pull up data line before reading
 
   uint32_t expectPulse(bool level);
 


### PR DESCRIPTION
This change sets _pullTime to a reasonable value if begin() isn't called.

It's arguably an error to not call begin(), but this used to work just fine in version 1.3.2. Right now, if you forget to call begin(), you just get bogus (or nan) values, and (with debugging enabled) DHT checksum errors.

With this change, if read() is called before begin() we'll print a helpful message if debugging is enabled, and continue with the default value of _pullTime.