### PR TITLE
heat index with refinements from NWS for lower values

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -175,9 +175,12 @@ float DHT::computeHeatIndex(bool isFahrenheit) {
 }
 
 /*!
- *  @brief  Compute Heat Index
- *  				Using both Rothfusz and Steadman's equations
+ *  @brief  Compute Heat Index (based on Robert G. Steadman tables)
+ *  				Using Rothfusz equations with refinements by the NWS
  *					(http://www.wpc.ncep.noaa.gov/html/heatindex_equation.shtml)
+ *                  and NWS algorithm that respects lower values of temperature
+ *                  and humidity
+ *                  (https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3801457/)
  *  @param  temperature
  *          temperature in selected scale
  *  @param  percentHumidity
@@ -192,6 +195,15 @@ float DHT::computeHeatIndex(float temperature, float percentHumidity,
 
   if (!isFahrenheit)
     temperature = convertCtoF(temperature);
+
+  if(temperature <= 40) {
+    return isFahrenheit ? temperature : convertFtoC(temperature);
+  }
+
+  float varA = -10.3 + 1.1 * temperature + 0.047 * percentHumidity;
+  if (varA < 79) {
+    return isFahrenheit ? varA : convertFtoC(varA);
+  }
 
   hi = 0.5 * (temperature + 61.0 + ((temperature - 68.0) * 1.2) +
               (percentHumidity * 0.094));


### PR DESCRIPTION
The current algorithm used for calculating heat index takes into account Rothfusz equation to achieve the values that Robert G. Steadman came up by experimentation. It then has some refinements done by the NWS but doesn't consider the other refinements that NWS did for lower values of temperature and humidity.

That's the reason why heat index for common house-hold values, like 74.84F and 68.5H give a heat index of 66.38F when in reality it should somewhere in the range of 75.23F - which makes more sense.

NWS full algo is very well detailed in this paper:
https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3801457/