### PR TITLE
'Hard' reset of a DHT Sensor via an assigned VCC Pin

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -430,7 +430,7 @@ void DHT::resetVCC_Pin(float f) {
     triesAvailable = (_tryCount < (_maxTries));
   }
 
-  if ((currenttime - _timeAtLastRestart >= _offInterval) & (triesAvailable)) {
+  if ((currenttime - _timeAtLastReset >= _offInterval) & (triesAvailable)) {
       //Toggles VCC pin between LOW and HIGH every _offInterval, 
       //depending on the current state of _VCC_stateSwitch
     if (!_VCC_stateSwitch) {
@@ -442,6 +442,6 @@ void DHT::resetVCC_Pin(float f) {
       _tryCount += 1;
     }
     
-    _timeAtLastRestart = currenttime;
+    _timeAtLastReset = currenttime;
   }
 }

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -392,7 +392,7 @@ uint32_t DHT::expectPulse(bool level) {
 
 /*!
  *  @brief  Set sensor to restart if it cannot be read by temporarily disabling power to sensor's 
- *          VCC pin, which is initiated with this function.
+ *          VCC pin, which is assigned with this function.
  *  @param  VCC_Pin
  *          Specify sensor's VCC power pin.
  *  @param  offInterval
@@ -405,6 +405,7 @@ void DHT::setPowerReset(uint8_t VCC_Pin, uint16_t offInterval, uint8_t maxTries)
   _offInterval = offInterval;
   _maxTries = maxTries;
 
+  //Initiate VCC Pin
   pinMode(_VCC_Pin, OUTPUT);
   digitalWrite(_VCC_Pin, HIGH);
 }
@@ -413,10 +414,11 @@ void DHT::setPowerReset(uint8_t VCC_Pin, uint16_t offInterval, uint8_t maxTries)
  *  @brief  If f is NAN, toggles the VCC power pin on and off as specified by
  *          setPowerReset() function.
  *  @param  f
- *          Sensor Reading from read functions, runs full function if NAN
+ *          Sensor Reading from read functions, runs full function if f == NAN
  */
 void DHT::resetVCC_Pin(float f) {
-  if (!isnan(f)) {
+  if (!isnan(f)) { 
+  	resets = resets + _tryCount;
     _tryCount = 0; 
     digitalWrite(_VCC_Pin, HIGH);
     return;

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -117,7 +117,7 @@ float DHT::readTemperature(bool S, bool force) {
       break;
     }
   }
-  // If VCC pin assigned, runs VCC pin restart funtion.
+  // If VCC pin assigned, runs VCC pin restart function.
   if (_VCC_Pin) { resetVCC_Pin(f); }
 
   return f;
@@ -160,7 +160,7 @@ float DHT::readHumidity(bool force) {
       break;
     }
   }
-  // If VCC pin assigned, runs VCC pin restart funtion.
+  // If VCC pin assigned, runs VCC pin restart function.
   if (_VCC_Pin) { resetVCC_Pin(f); }
 
   return f;
@@ -396,7 +396,7 @@ uint32_t DHT::expectPulse(bool level) {
  *  @param  VCC_Pin
  *          Specify sensor's VCC power pin.
  *  @param  offInterval
- *          The amount of time in milliseconds to turn off power to sensor during reset.
+ *          The amount of time in milliseconds to cycle on/off the power to sensor during reset.
  *  @param  maxTries
  *          Will attempt reset this many times. 0 for infinite
  */
@@ -414,7 +414,7 @@ void DHT::setPowerReset(uint8_t VCC_Pin, uint16_t offInterval, uint8_t maxTries)
  *  @brief  If f is NAN, toggles the VCC power pin on and off as specified by
  *          setPowerReset() function.
  *  @param  f
- *          Sensor Reading from read functions, runs full function if f == NAN
+ *          Sensor reading from read functions, runs full function if NAN
  */
 void DHT::resetVCC_Pin(float f) {
   if (!isnan(f)) { 

--- a/DHT.h
+++ b/DHT.h
@@ -56,6 +56,8 @@ class DHT {
    float readHumidity(bool force=false);
    bool read(bool force=false);
 
+   void setPowerReset(uint8_t VCC_pin, uint16_t offInterval = 1000, uint8_t maxTries = 0);
+
  private:
   uint8_t data[5];
   uint8_t _pin, _type;
@@ -70,6 +72,13 @@ class DHT {
 
   uint32_t expectPulse(bool level);
 
+  /* Variables for powerReset function */
+  uint8_t _VCC_Pin, _tryCount, _maxTries;
+  uint16_t _offInterval;
+  uint32_t _timeAtLastRestart = 0;
+  bool _VCC_stateSwitch = false;
+
+  void DHT::resetVCC_Pin(float f);
 };
 
 /*! 

--- a/DHT.h
+++ b/DHT.h
@@ -75,7 +75,7 @@ class DHT {
   /* Variables for powerReset function */
   uint8_t _VCC_Pin, _tryCount, _maxTries;
   uint16_t _offInterval;
-  uint32_t _timeAtLastRestart = 0;
+  uint32_t _timeAtLastReset = 0;
   bool _VCC_stateSwitch = false;
 
   void DHT::resetVCC_Pin(float f);

--- a/DHT.h
+++ b/DHT.h
@@ -80,7 +80,7 @@ class DHT {
   uint32_t _timeAtLastReset = 0;
   bool _VCC_stateSwitch = false;
 
-  void DHT::resetVCC_Pin(float f);
+  void resetVCC_Pin(float f);
 };
 
 /*! 

--- a/DHT.h
+++ b/DHT.h
@@ -56,7 +56,9 @@ class DHT {
    float readHumidity(bool force=false);
    bool read(bool force=false);
 
+  /* VCC Power Hard Reset function */
    void setPowerReset(uint8_t VCC_pin, uint16_t offInterval = 1000, uint8_t maxTries = 0);
+   uint8_t resets; //Keeps track of reset attempts
 
  private:
   uint8_t data[5];

--- a/keywords.txt
+++ b/keywords.txt
@@ -19,4 +19,4 @@ convertFtoC	KEYWORD2
 computeHeatIndex	KEYWORD2
 readHumidity	KEYWORD2
 read	KEYWORD2
-
+setPowerReset KEYWORD2


### PR DESCRIPTION
I added two functions, public **_setPowerReset()_** and private **_resetVCC_pin()_**, which allow for a 'hard' power reset of a DHT sensor when the sensor fails to read the temperature or humidity. The sensor's VCC pin must be plugged into an Arduino digital pin instead of directly into the Arduino's VCC pin, and the pin will be cycled between _digitalWrite()_ LOW and HIGH if reading from the sensor fails.

This came about because in one of my setups controlling a plant terrarium, my DHT22 would periodically fail to read and never recover. However, when I unplugged and reconnected the VCC pin to the sensor, it would read fine again. 

These modifications have fixed my problem and I can once again read from the sensor indefinitely without issues. I am a newb in many respects and understand this could be a problem with something else in my system - whether it be a hardware component or something in my code, but having not found another source, this has been an effective solution. (My setup consists of an UNO R3, a DHT22 sensor, A DS3231 clock module, a LCD 1602 display module, and a 74HC595 Serial to Parallel chip outputting to some relays, all connected with a breadboard.)

The _setPowerReset()_ function can be run once to activate the reset function. It takes 3 arguments: 
  - _VCC_Pin_, which assigns the VCC/power Pin
  - _offInterval_, which assigns the amount of time the VCC power is cycled in milliseconds. It's an unsigned 16 bit int, so the on/off time can theoretically be up to 65535 milliseconds. Optional w/ default of 1000. 
  - _maxTries_, which sets the maximum amount of times the reset will happen while the sensor fails to read before the function 'gives up', up to 255. Optional - don't include this argument, or set to 0, for infinite resets.

The Private function _resetVCC_Pin()_ is what does the actual reset. I placed it at the end of the _readTemperature()_ and _readHumidity()_ functions and it accepts the sensor reading result as an argument, cycling the power if it recieves a NAN. _resetVCC_Pin()_ only runs if a VCC pin is assigned by _setPowerReset()_. 

I also added a public uint8_t variable _resets_ to keep track of the number of times the power has been cycled.

I know that these changes are probably solving a problem that is too esoteric to be considered for the official Adafruit repository, but I thought I'd post it in case it's helpful. I will probably maintain my own repository in case this is useful to anyone else.
