### PR TITLE
Add missing microsecondsToClockCycles for 33 BLE

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -48,7 +48,7 @@
 #define AM2301 21 /**< AM2301 */
 
 #if (TARGET_NAME == ARDUINO_NANO33BLE)
-// As of 7 Sep 2020 the Arduino Nano 33 BLE boards do not have 
+// As of 7 Sep 2020 the Arduino Nano 33 BLE boards do not have
 // microsecondsToClockCycles defined.
 #ifndef microsecondsToClockCycles
 #define microsecondsToClockCycles(a) ((a) * (SystemCoreClock / 1000000L))

--- a/DHT.h
+++ b/DHT.h
@@ -48,9 +48,11 @@
 #define AM2301 21 /**< AM2301 */
 
 #if (TARGET_NAME == ARDUINO_NANO33BLE)
-// As of 7 Sep 2020 the Arduino Nano 33 BLE boards do not have
-// microsecondsToClockCycles defined.
 #ifndef microsecondsToClockCycles
+/*!
+ * As of 7 Sep 2020 the Arduino Nano 33 BLE boards do not have
+ * microsecondsToClockCycles defined.
+ */
 #define microsecondsToClockCycles(a) ((a) * (SystemCoreClock / 1000000L))
 #endif
 #endif

--- a/DHT.h
+++ b/DHT.h
@@ -47,6 +47,13 @@
 #define DHT21 21  /**< DHT TYPE 21 */
 #define AM2301 21 /**< AM2301 */
 
+#if (TARGET_NAME==ARDUINO_NANO33BLE)
+// As of 7 Sep 2020 the Arduino Nano 33 BLE boards do not have microsecondsToClockCycles defined.
+#ifndef microsecondsToClockCycles
+#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
+#endif
+#endif
+
 /*!
  *  @brief  Class that stores state and functions for DHT
  */

--- a/DHT.h
+++ b/DHT.h
@@ -47,10 +47,11 @@
 #define DHT21 21  /**< DHT TYPE 21 */
 #define AM2301 21 /**< AM2301 */
 
-#if (TARGET_NAME==ARDUINO_NANO33BLE)
-// As of 7 Sep 2020 the Arduino Nano 33 BLE boards do not have microsecondsToClockCycles defined.
+#if (TARGET_NAME == ARDUINO_NANO33BLE)
+// As of 7 Sep 2020 the Arduino Nano 33 BLE boards do not have 
+// microsecondsToClockCycles defined.
 #ifndef microsecondsToClockCycles
-#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
+#define microsecondsToClockCycles(a) ((a) * (SystemCoreClock / 1000000L))
 #endif
 #endif
 


### PR DESCRIPTION
The Arduino Nano 33 BLE (and 33 BLE Sense) boards are based on mbed OS.  Currently Arduino has not included the microsecondsToClockCycles() function in Arduino.h (or standard include files).  There is some debate as to whether
or not the function belongs in the standard Arduino.h for this board.  (See issue 101 here [here](https://github.com/arduino/ArduinoCore-nRF528x-mbedos/issues/101)).

This change adds the missing definition of microsecondsToClockCycles() to DHT.h only for the Nano 33 BLE Board only and only if it's not eventually included in the standard include.

There are no known limitations.

Testing has been verified on Arduino Uno, Arduino 33 IoT, and Arduino 33 BLE Sense boards with a DHT11 sensor.