### PR TITLE
Make preprocessor conditional false when identifier undefined

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -47,7 +47,7 @@
 #define DHT21 21  /**< DHT TYPE 21 */
 #define AM2301 21 /**< AM2301 */
 
-#if (TARGET_NAME == ARDUINO_NANO33BLE)
+#if defined(TARGET_NAME) && (TARGET_NAME == ARDUINO_NANO33BLE)
 #ifndef microsecondsToClockCycles
 /*!
  * As of 7 Sep 2020 the Arduino Nano 33 BLE boards do not have


### PR DESCRIPTION
A preprocessor conditional directive intended to only evaluate as true when compiling for the Arduino Nano 33 BLE board
was also evaluating as true when compiling for any board that didn't define the compared identifiers because undefined
identifiers are replaced with 0 by the C/C++ preprocessor, making them equal.

From the C++11 standard section 16.1, paragraph 4:

> After all replacements due to macro expansion and the defined unary operator
have been performed, all remaining identifiers and keywords 148 , except for true and false, are replaced
with the pp-number 0

The fix is to modify the directive to check whether the macro has been defined.

---
Examples tested working on Nano 33 BLE, Uno WiFi Rev2, Uno with DHT11

---
Fixes https://github.com/adafruit/DHT-sensor-library/issues/172