### PR TITLE
Problem: wrong values at negative temperatures an ESP8266 and DHT22

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -109,11 +109,8 @@ float DHT::readTemperature(bool S, bool force) {
       break;
     case DHT22:
     case DHT21:
-      f = ((word)(data[2] & 0x7F)) << 8 | data[3];
-      f *= 0.1;
-      if (data[2] & 0x80) {
-        f *= -1;
-      }
+      int16_t t = ((int16_t)data[2] << 8) | data[3];
+      f = t * 0.1;
       if (S) {
         f = convertCtoF(f);
       }


### PR DESCRIPTION
Problem is described in #177 

Solution:
shift incomming data on int16_t variable before cast to float.

I could test this solution only on Arduino IDE 1.8.13 with ESP8266 / DHT 22.
Maybe testing on other controllers / dht types could be necessery