### PR TITLE
Use const instead of defines for sensors types

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -41,11 +41,11 @@
 #endif
 
 /* Define types of sensors. */
-#define DHT11 11  /**< DHT TYPE 11 */
-#define DHT12 12  /**< DHY TYPE 12 */
-#define DHT22 22  /**< DHT TYPE 22 */
-#define DHT21 21  /**< DHT TYPE 21 */
-#define AM2301 21 /**< AM2301 */
+static const uint8_t DHT11{11};  /**< DHT TYPE 11 */
+static const uint8_t DHT12{12};  /**< DHY TYPE 12 */
+static const uint8_t DHT21{21};  /**< DHT TYPE 22 */
+static const uint8_t DHT22{22};  /**< DHT TYPE 21 */
+static const uint8_t AM2301{21}; /**< AM2301 */
 
 #if defined(TARGET_NAME) && (TARGET_NAME == ARDUINO_NANO33BLE)
 #ifndef microsecondsToClockCycles


### PR DESCRIPTION
Those names may be used in user's code.<br>
Polluting the code with those macros may result in unexpected parsing errors.