### PR TITLE
Fix infinite loop on STM32F103

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -360,7 +360,9 @@ bool DHT::read(bool force) {
 // in the very latest IDE versions):
 //   https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/cores/arduino/wiring_pulse.c
 uint32_t DHT::expectPulse(bool level) {
-#if (F_CPU > 16000000L)
+// F_CPU is not be known at compile time on platforms such as STM32F103.
+// The preprocessor seems to evaluate it to zero in that case.
+#if (F_CPU > 16000000L) || (F_CPU == 0L)
   uint32_t count = 0;
 #else
   uint16_t count = 0; // To work fast enough on slower AVR boards


### PR DESCRIPTION
When trying to read temperature from a DHT11 with the **sensor disconnected**, the program would encounter an infinite loop in `DHT::expectPulse`, because `count` would keep overflowing.

This PR changes the preprocessor `#if` expression so that if `F_CPU == 0L` is true (which it is in my case with `STM32F103C8`. I _think_ `F_CPU` contains the name of a variable), 32 bits is allocated for `count` instead of the insufficient 16 bits.

This could potentially break platforms where `F_CPU` is also evaluated to 0 by the preprocessor, but working with an `uint32_t` makes the code run too slow. A less intrusive fix would be to add `|| defined(ARDUINO_BLUEPILL_F103C8)` instead. However, that would not fix the problem for other platforms like STM32F401, where it is also present.