### PR TITLE
Feature/add set pin and type

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -72,10 +72,20 @@ void DHT::begin(uint8_t usec) {
   pullTime = usec;
 }
 
+/*!
+ *  @brief  Sets the _pin property value
+ *  @param  newPin
+ *          pin number that sensor is connected
+ */
 void DHT::setPin(uint8_t newPin){
 	_pin = newPin;
 }
 
+/*!
+ *  @brief  Sets the _type property value
+ *  @param  newType
+ *          type of sensor
+ */
 void DHT::setType(uint8_t newType){
 	_type = newType;
 }

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -72,6 +72,14 @@ void DHT::begin(uint8_t usec) {
   pullTime = usec;
 }
 
+void DHT::setPin(uint8_t newPin){
+	_pin = newPin;
+}
+
+void DHT::setType(uint8_t newType){
+	_type = newType;
+}
+
 /*!
  *  @brief  Read temperature
  *  @param  S

--- a/DHT.h
+++ b/DHT.h
@@ -64,6 +64,8 @@ class DHT {
 public:
   DHT(uint8_t pin, uint8_t type, uint8_t count = 6);
   void begin(uint8_t usec = 55);
+  void setPin(uint8_t newPin);
+  void setType(uint8_t newType);
   float readTemperature(bool S = false, bool force = false);
   float convertCtoF(float);
   float convertFtoC(float);


### PR DESCRIPTION
This adds two new methods to the DHT class. One for setting the _pin value and one for setting the _type value. The reason I added these was so that I could use values stored in eeprom for my pin and type and set these values in my setup() function.
