### PR TITLE
Core 1 panic'ed (Interrupt wdt timeout on CPU1) on ESP32

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -318,11 +318,7 @@ bool DHT::read(bool force) {
   for (int i = 0; i < 40; ++i) {
     uint32_t lowCycles = cycles[2 * i];
     uint32_t highCycles = cycles[2 * i + 1];
-    if ((lowCycles == TIMEOUT) || (highCycles == TIMEOUT)) {
-      DEBUG_PRINTLN(F("DHT timeout waiting for pulse."));
-      _lastresult = false;
-      return _lastresult;
-    }
+
     data[i / 8] <<= 1;
     // Now compare the low and high cycle times to see if the bit is a 0 or 1.
     if (highCycles > lowCycles) {

--- a/DHT.cpp
+++ b/DHT.cpp
@@ -304,6 +304,12 @@ bool DHT::read(bool force) {
     for (int i = 0; i < 80; i += 2) {
       cycles[i] = expectPulse(LOW);
       cycles[i + 1] = expectPulse(HIGH);
+
+      if (cycles[i]==TIMEOUT || cycles[i+1]==TIMEOUT){
+        DEBUG_PRINTLN(F("DHT timeout waiting for data signal."));
+        _lastresult = false;
+        return _lastresult;
+      }
     }
   } // Timing critical code is now complete.
 


### PR DESCRIPTION
Sometimes I got a core 1 panic (Interrupt wdt timeout on CPU1). The timeout occured in the expectPulse function. This was the case because the cpu stayed the most time (up to 1ms) in the while loop of this function when the sensor didn't deliver useable information. Because there is no timeout check in the critical section of the read-function, the expectPulse function was called 80 times, what lead under certain conditions to a wdt timeout - even with a default wdt timeout setting of 300ms. 

I've just moved the timeout-check in the critical section and the problem disappeared. 