### PR TITLE
[DHT22] modified interpretation of temperature values in byte 2 and 3, such that negative temperature values are handled correctly

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -84,6 +84,7 @@ void DHT::begin(uint8_t usec) {
  */
 float DHT::readTemperature(bool S, bool force) {
   float f = NAN;
+  short s = 0;
 
   if (read(force)) {
     switch (_type) {
@@ -108,6 +109,12 @@ float DHT::readTemperature(bool S, bool force) {
       }
       break;
     case DHT22:
+      s = ((short) data[2]) << 8 | data[3];
+      f = s * 0.1;
+      if (S) {
+        f = convertCtoF(f);
+      }
+      break;
     case DHT21:
       f = ((word)(data[2] & 0x7F)) << 8 | data[3];
       f *= 0.1;


### PR DESCRIPTION
This pull request solves the issue described in #221.

Negative temperature values from a DHT22 sensor can be interpreted as a 16 bit signed integer (short). There is no additional differentiation needed.
```
float DHT::readTemperature(bool S, bool force) {
  float f = NAN;
  short s = 0;
...
    case DHT22:
      s = ((short) data[2]) << 8 | data[3];
      f = s * 0.1;
      if (S) {
        f = convertCtoF(f);
      }
      break;
... 
```

The patch was successfully tested using five different DHT22 sensors on an Arduino UNO and an ESP8266 at positive and negative temperatures.