### PR TITLE
Fixs I fixed the DHT11 NOT being refreshed at 1 second intervals. fixed (#206)

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -43,6 +43,12 @@ DHT::DHT(uint8_t pin, uint8_t type, uint8_t count) {
   (void)count; // Workaround to avoid compiler warning.
   _pin = pin;
   _type = type;
+    // Adjust MIN_INTERVAL based on sensor type
+  if (_type == DHT11) {
+    _minInterval = 1000; // 1 second for DHT11
+  } else {
+    _minInterval = 2000; // 2 seconds for other types
+  }
 #ifdef __AVR
   _bit = digitalPinToBitMask(pin);
   _port = digitalPinToPort(pin);

--- a/DHT.h
+++ b/DHT.h
@@ -76,6 +76,7 @@ public:
 private:
   uint8_t data[5];
   uint8_t _pin, _type;
+  uint32_t _minInterval; // Minimum interval between reads
 #ifdef __AVR
   // Use direct GPIO access on an 8-bit AVR so keep track of the port and
   // bitmask for the digital pin connected to the DHT.  Other platforms will use


### PR DESCRIPTION
I have made modifications to the files DHT.cpp and DHT.h. The objective is to enable the DHT11 sensor to refresh at its designated refresh rate and to allow the setup to determine whether the user is utilizing a DHT11 or a different sensor.

I have verified its functionality on my end, but it would be beneficial if @cryptoAlgorithm could test it for additional confirmation.
